### PR TITLE
Check for optional ARG_FILENAME and ARG_CHECKSUM

### DIFF
--- a/android/src/main/java/sk/fourq/otaupdate/OtaUpdatePlugin.java
+++ b/android/src/main/java/sk/fourq/otaupdate/OtaUpdatePlugin.java
@@ -116,10 +116,10 @@ public class OtaUpdatePlugin implements EventChannel.StreamHandler, PluginRegist
         } catch (JSONException e) {
             Log.e(TAG, "ERROR: " + e.getMessage(), e);
         }
-        if (argumentsMap.containsKey(ARG_FILENAME)) {
+        if (argumentsMap.containsKey(ARG_FILENAME) && argumentsMap.get(ARG_FILENAME) != null) {
             filename = argumentsMap.get(ARG_FILENAME).toString();
         }
-        if (argumentsMap.containsKey(ARG_CHECKSUM)) {
+        if (argumentsMap.containsKey(ARG_CHECKSUM) && argumentsMap.get(ARG_CHECKSUM) != null) {
             checksum = argumentsMap.get(ARG_CHECKSUM).toString();
         }
 


### PR DESCRIPTION
When trying to update the apk without a provided filename or checksum a NullPointerException raises on line 120 or 123. This PR checks if ARG_FILENAME and ARG_CHECKSUM is null before calling toString()