### PR TITLE
Add namespace field to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,8 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
 
+    namespace 'sk.fourq.otaupdate'
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Summary

On Flutter 3.16, kiosk_mode package fails to build with the error message below:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':ota_update'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

That's why I added namespace field to build.gradle file.