### PR TITLE
Allow to cancel the currently active ota download

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Plugin now allows you to get android ABI platform. If your are building multiple
 * INTERNAL_ERROR: 
     * sent in all other error cases
     * event value is underlying error message
+* CANCELED:
+  * sent when the download was canceled using 'OtaUpdate().cancel()'
 
 ## TODO
 * restrict download to specific connection type (mobile, wifi)

--- a/android/src/main/java/sk/fourq/otaupdate/OtaUpdatePlugin.java
+++ b/android/src/main/java/sk/fourq/otaupdate/OtaUpdatePlugin.java
@@ -122,7 +122,7 @@ public class OtaUpdatePlugin implements FlutterPlugin, ActivityAware, EventChann
         Log.d(TAG, "onMethodCall "+call.method);
         if (call.method.equals("getAbi")) {
             result.success(Build.SUPPORTED_ABIS[0]);
-        } else if(call.method.equals("cancel")) {
+        } else if (call.method.equals("cancel")) {
             if (currentCall != null) {
                 currentCall.cancel();
                 currentCall = null;

--- a/lib/ota_update.dart
+++ b/lib/ota_update.dart
@@ -17,6 +17,11 @@ class OtaUpdate {
     return _methodChannel.invokeMethod<String>('getAbi');
   }
 
+  /// Cancel the currently active ota download if there is one
+  Future<void> cancel() async {
+    return _methodChannel.invokeMethod<void>('cancel');
+  }
+
   /// Execute download and instalation of the plugin.
   /// Download progress and all success or error states are publish in stream as OtaEvent
   Stream<OtaEvent> execute(
@@ -95,7 +100,10 @@ enum OtaStatus {
   /// CHECKSUM VERIFICATION FAILED. MOSTLY THIS IS DUE INCORRECT OR CORRUPTED FILE
   /// THIS IS ALSO RETURNED IF PLUGIN WAS UNABLE TO CALCULATE SHA 256 HASH OF DOWNLOADED FILE
   /// SEE VALUE FOR MORE INFORMATION
-  CHECKSUM_ERROR
+  CHECKSUM_ERROR,
+
+  /// DOWNLOAD WAS CANCELED
+  CANCELED
 }
 
 /// EXCEPTION FOR QUICK IDENTIFICATION OF ERRORS THROWN FROM THIS PLUGIN.


### PR DESCRIPTION
Adds a new method to `OtaUpdate` that allows to cancel the currently active OTA download. This is useful if you want to provide an user interface that allows the user to cancel the download and try it again at a later time (e.g. because they currently have a bad network connection).