### PR TITLE
Support parallel range downloads on Android

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -88,6 +88,8 @@ try {
       destinationFilename: 'flutter_hello_world.apk',
       // 可选，仅 Android - 能够验证文件的校验和：
       sha256checksum: "d6da28451a1e15cf7a75f2c3f151befad3b80ad0bb232ab15c20897e54f21478",
+      // 可选，仅 Android - 在服务器支持时使用多个 HTTP Range 请求：
+      parallelDownloads: 4,
     ).listen(
       (OtaEvent event) {
         setState(() => currentEvent = event);
@@ -210,6 +212,19 @@ android:networkSecurityConfig="@xml/network_security_config"
 
 此包支持文件完整性的 sha256 校验和验证。这使我们能够检测文件在传输过程中是否已损坏
 要使用此功能，你的更新服务器应向你提供 APK 的 sha256 校验和，并且你需要在检查更新时获取此值。当你使用此参数运行 `execute` 方法时，插件将从下载的文件计算 sha256 值，并与提供的值进行比较。只有当两个值匹配时，更新才会继续，否则会抛出错误。
+
+#### 使用 parallelDownloads（仅 Android）
+
+默认情况下，插件使用单个 HTTP 请求下载 APK，以保持历史行为不变。如果你的更新服务器支持 HTTP Range 请求，可以将 `parallelDownloads` 设置为大于 1 的值来启用并行下载：
+
+```dart
+OtaUpdate().execute(
+  apkUrl,
+  parallelDownloads: 4,
+);
+```
+
+Android 实现会先使用 Range 请求探测服务器能力。如果服务器没有返回有效的 `206 Partial Content` 响应和总大小，插件会自动回退到默认的单请求下载。超过 8 的值会被截断。
 
 #### 使用拆分 apks（实验性）
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ import 'package:ota_update/ota_update.dart';
         destinationFilename: 'flutter_hello_world.apk',
         //OPTIONAL, ANDROID ONLY - ABILITY TO VALIDATE CHECKSUM OF FILE:
         sha256checksum: "d6da28451a1e15cf7a75f2c3f151befad3b80ad0bb232ab15c20897e54f21478",
+        //OPTIONAL, ANDROID ONLY - USE MULTIPLE HTTP RANGE REQUESTS WHEN SUPPORTED:
+        parallelDownloads: 4,
       ).listen(
         (OtaEvent event) {
           setState(() => currentEvent = event);
@@ -212,6 +214,19 @@ Since this plugin only handles download and installation, there are still a few 
 
 This package supports sha256 checksum verification of the file integrity. This allows as to detect if file has been corrupted during transfer.
 To use this feature, your update server should provide you with sha256 checksum of APK and you need to obtain this value while you are checking for update. When you run ```execute``` method with this parameter, plugin will compute sha256 value from downloaded file and compare with provided value. The update will continiue only if the two values match, otherwise it throws error.
+
+#### Using parallelDownloads (Android only)
+
+By default the plugin downloads APKs with a single HTTP request, preserving the historical behavior. If your update server supports HTTP range requests, you can opt in to a parallel download by setting ```parallelDownloads``` to a value greater than 1:
+
+```dart
+OtaUpdate().execute(
+  apkUrl,
+  parallelDownloads: 4,
+);
+```
+
+The Android implementation first probes the server with a range request. If the server does not return a valid ```206 Partial Content``` response with a total size, the plugin automatically falls back to the default single request download. Values above 8 are capped.
 
 #### Using split apks (experimental)
 

--- a/android/src/main/java/sk/fourq/otaupdate/OtaUpdatePlugin.java
+++ b/android/src/main/java/sk/fourq/otaupdate/OtaUpdatePlugin.java
@@ -31,6 +31,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.internal.http2.StreamResetException;
 import okio.BufferedSink;
+import okio.BufferedSource;
 import okio.Okio;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -41,11 +42,15 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * OtaUpdatePlugin
@@ -68,10 +73,12 @@ public class OtaUpdatePlugin implements
     private static final String ARG_FILENAME = "filename";
     private static final String ARG_CHECKSUM = "checksum";
     private static final String ARG_ANDROID_PROVIDER_AUTHORITY = "androidProviderAuthority";
+    private static final String ARG_PARALLEL_DOWNLOADS = "parallelDownloads";
     public static final String TAG = "FLUTTER OTA";
     private static final String DEFAULT_APK_NAME = "ota_update.apk";
     private static final String STREAM_CHANNEL = "sk.fourq.ota_update/stream";
     private static final String METHOD_CHANNEL = "sk.fourq.ota_update/method";
+    private static final int MAX_PARALLEL_DOWNLOADS = 8;
 
     // CONTENT LENGTH FOR PROGRESS REPORTING
     private Long contentLength;
@@ -84,15 +91,21 @@ public class OtaUpdatePlugin implements
     private String androidProviderAuthority;
     private BinaryMessenger messanger;
     private OkHttpClient client;
+    private OkHttpClient rawClient;
     private InstallSessionCallback installSessionCallback;
 
     //DOWNLOAD SPECIFIC PLUGIN STATE. PLUGIN SUPPORT ONLY ONE DOWNLOAD AT A TIME
+    private final Object callsLock = new Object();
+    private final List<Call> currentCalls = new ArrayList<>();
     private Call currentCall;
     private String downloadUrl;
     private JSONObject headers;
     private String filename;
     private String checksum;
     private boolean usePackageInstaller = false;
+    private int parallelDownloads = 1;
+    private volatile boolean downloadRunning = false;
+    private volatile boolean downloadCancelled = false;
 
     //FLUTTER EMBEDDING V2 - PLUGIN BINDING
     @Override
@@ -138,9 +151,9 @@ public class OtaUpdatePlugin implements
         if (call.method.equals("getAbi")) {
             result.success(Build.SUPPORTED_ABIS[0]);
         } else if (call.method.equals("cancel")) {
-            if (currentCall != null) {
-                currentCall.cancel();
-                currentCall = null;
+            if (downloadRunning || hasActiveCalls()) {
+                cancelActiveCalls();
+                downloadRunning = false;
                 reportStatus(true, OtaStatus.CANCELED, "Call was canceled using cancel()", null, null);
             }
             result.success(null);
@@ -165,11 +178,16 @@ public class OtaUpdatePlugin implements
             reportStatus(true, OtaStatus.INTERNAL_ERROR, "Invalid arguments passed to onListen()", ex, null);
             return;
         }
+        headers = null;
+        checksum = null;
+        usePackageInstaller = false;
+        parallelDownloads = 1;
         downloadUrl = argumentsMap.get(ARG_URL);
         String rawUsePackageInstaller = argumentsMap.get(ARG_USE_PACKAGE_INSTALLER);
         if (rawUsePackageInstaller != null) {
             usePackageInstaller = rawUsePackageInstaller.equals("true");
         }
+        parallelDownloads = parseParallelDownloads(argumentsMap.get(ARG_PARALLEL_DOWNLOADS));
         try {
             String headersJson = argumentsMap.get(ARG_HEADERS);
             if (headersJson != null && !headersJson.isEmpty()) {
@@ -200,9 +218,26 @@ public class OtaUpdatePlugin implements
         throw new IllegalArgumentException();
     }
 
+    private int parseParallelDownloads(String rawParallelDownloads) {
+        if (rawParallelDownloads == null) {
+            return 1;
+        }
+        try {
+            int parsed = Integer.parseInt(rawParallelDownloads);
+            return Math.max(1, Math.min(parsed, MAX_PARALLEL_DOWNLOADS));
+        } catch (NumberFormatException ex) {
+            Log.w(TAG, "Invalid parallelDownloads value: " + rawParallelDownloads, ex);
+            return 1;
+        }
+    }
+
     @Override
     public void onCancel(Object o) {
         Log.d(TAG, "STREAM CLOSED");
+        if (downloadRunning || hasActiveCalls()) {
+            cancelActiveCalls();
+            downloadRunning = false;
+        }
         closeSink();
     }
 
@@ -230,10 +265,13 @@ public class OtaUpdatePlugin implements
      */
     private void executeDownload() {
         try {
-            if (currentCall != null) {
+            if (downloadRunning) {
                 reportStatus(true, OtaStatus.ALREADY_RUNNING_ERROR, "Another download (call) is already running", null, null);
                 return;
             }
+            downloadRunning = true;
+            downloadCancelled = false;
+            contentLength = null;
 
             String dataDir = context.getApplicationInfo().dataDir + "/files/ota_update";
             //PREPARE URLS
@@ -248,58 +286,338 @@ public class OtaUpdatePlugin implements
                 }
             } else if (file.getParentFile() != null && !file.getParentFile().exists()) {
                 if (!file.getParentFile().mkdirs()) {
+                    clearActiveCallReferences();
                     reportStatus(true, OtaStatus.INTERNAL_ERROR, "unable to create ota_update folder in internal storage", null, null);
+                    return;
                 }
             }
 
-            Log.d(TAG, "DOWNLOAD STARTING");
-            Request.Builder request = new Request.Builder()
-                    .url(downloadUrl);
-            if (headers != null) {
-                Iterator<String> jsonKeys = headers.keys();
-                while (jsonKeys.hasNext()) {
-                    String headerName = jsonKeys.next();
-                    String headerValue = headers.getString(headerName);
-                    request.addHeader(headerName, headerValue);
+            if (parallelDownloads > 1) {
+                Log.d(TAG, "DOWNLOAD STARTING WITH " + parallelDownloads + " CONNECTIONS");
+                startParallelDownload(destination, fileUri, file);
+            } else {
+                Log.d(TAG, "DOWNLOAD STARTING");
+                startSingleDownload(destination, fileUri, file);
+            }
+        } catch (Exception e) {
+            clearActiveCallReferences();
+            reportStatus(true, OtaStatus.INTERNAL_ERROR, e.getMessage(), e, null);
+        }
+    }
+
+    private void startSingleDownload(final String destination, final Uri fileUri, final File file) throws JSONException {
+        if (downloadCancelled) {
+            clearActiveCallReferences();
+            return;
+        }
+        Request.Builder request = buildRequest(downloadUrl);
+
+        currentCall = client.newCall(request.build());
+        currentCall.enqueue(new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                if (downloadCancelled) {
+                    clearActiveCallReferences();
+                    return;
+                }
+                clearActiveCallReferences();
+                reportStatus(true, OtaStatus.DOWNLOAD_ERROR, e.getMessage(), e, null);
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try {
+                    if (downloadCancelled) {
+                        return;
+                    }
+                    if (!response.isSuccessful()) {
+                        clearActiveCallReferences();
+                        reportStatus(true, OtaStatus.DOWNLOAD_ERROR, "Http request finished with status " + response.code(), null, null);
+                        return;
+                    }
+                    try (BufferedSink sink = Okio.buffer(Okio.sink(file))) {
+                        if (response.body() != null) {
+                            sink.writeAll(response.body().source());
+                        }
+                    }
+                } catch (StreamResetException ex) {
+                    // Thrown when the call was canceled using 'cancel()'
+                    return;
+                } catch (IOException | RuntimeException ex) {
+                    clearActiveCallReferences();
+                    reportStatus(true, OtaStatus.DOWNLOAD_ERROR, ex.getMessage(), ex, null);
+                    return;
+                } finally {
+                    response.close();
+                }
+                clearActiveCallReferences();
+                onDownloadComplete(destination, fileUri);
+            }
+        });
+    }
+
+    private void startParallelDownload(final String destination, final Uri fileUri, final File file) throws JSONException {
+        Request probeRequest = buildRequest(downloadUrl)
+                .header("Range", "bytes=0-0")
+                .build();
+        currentCall = rawClient.newCall(probeRequest);
+        currentCall.enqueue(new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                if (downloadCancelled) {
+                    clearActiveCallReferences();
+                    return;
+                }
+                Log.w(TAG, "Range probe failed. Falling back to single connection download.", e);
+                currentCall = null;
+                try {
+                    startSingleDownload(destination, fileUri, file);
+                } catch (JSONException ex) {
+                    clearActiveCallReferences();
+                    reportStatus(true, OtaStatus.DOWNLOAD_ERROR, ex.getMessage(), ex, null);
                 }
             }
 
-            currentCall = client.newCall(request.build());
-            currentCall.enqueue(new Callback() {
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try {
+                    currentCall = null;
+                    if (downloadCancelled) {
+                        return;
+                    }
+                    long totalLength = parseTotalLengthFromContentRange(response.header("Content-Range"));
+                    if (response.code() != 206 || totalLength < 1) {
+                        Log.d(TAG, "Server does not support range requests. Falling back to single connection download.");
+                        startSingleDownload(destination, fileUri, file);
+                        return;
+                    }
+                    startRangeDownloads(destination, fileUri, file, totalLength);
+                } catch (JSONException ex) {
+                    clearActiveCallReferences();
+                    reportStatus(true, OtaStatus.DOWNLOAD_ERROR, ex.getMessage(), ex, null);
+                } finally {
+                    response.close();
+                }
+            }
+        });
+    }
+
+    private void startRangeDownloads(final String destination, final Uri fileUri, final File file, final long totalLength) throws JSONException {
+        if (downloadCancelled) {
+            clearActiveCallReferences();
+            return;
+        }
+        int connectionCount = (int) Math.min(parallelDownloads, totalLength);
+        if (connectionCount <= 1) {
+            startSingleDownload(destination, fileUri, file);
+            return;
+        }
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
+            randomAccessFile.setLength(totalLength);
+        } catch (IOException | RuntimeException ex) {
+            clearActiveCallReferences();
+            reportStatus(true, OtaStatus.DOWNLOAD_ERROR, ex.getMessage(), ex, null);
+            return;
+        }
+
+        contentLength = totalLength;
+        reportDownloadProgress(0, totalLength);
+
+        AtomicInteger completedParts = new AtomicInteger(0);
+        AtomicBoolean finished = new AtomicBoolean(false);
+        AtomicLong totalDownloaded = new AtomicLong(0);
+
+        for (int i = 0; i < connectionCount; i++) {
+            final long start = (totalLength * i) / connectionCount;
+            final long end = ((totalLength * (i + 1)) / connectionCount) - 1;
+            final int partIndex = i;
+
+            Request partRequest = buildRequest(downloadUrl)
+                    .header("Range", "bytes=" + start + "-" + end)
+                    .build();
+            Call partCall = rawClient.newCall(partRequest);
+            addActiveCall(partCall);
+            partCall.enqueue(new Callback() {
                 @Override
                 public void onFailure(@NotNull Call call, @NotNull IOException e) {
-                    reportStatus(true, OtaStatus.DOWNLOAD_ERROR, e.getMessage(), e, null);
-                    currentCall = null;
+                    removeActiveCall(call);
+                    if (downloadCancelled || finished.get()) {
+                        return;
+                    }
+                    failParallelDownload(finished, "Part " + partIndex + " failed: " + e.getMessage(), e);
                 }
 
                 @Override
                 public void onResponse(@NotNull Call call, @NotNull Response response) {
-                    if (!response.isSuccessful()) {
-                        reportStatus(true, OtaStatus.DOWNLOAD_ERROR, "Http request finished with status " + response.code(), null, null);
-                    }
                     try {
-                        BufferedSink sink = Okio.buffer(Okio.sink(file));
-                        if (response.body() != null) {
-                            sink.writeAll(response.body().source());
+                        if (downloadCancelled || finished.get()) {
+                            return;
                         }
-                        sink.close();
+                        if (response.code() != 206 || response.body() == null) {
+                            failParallelDownload(finished, "Part " + partIndex + " finished with status " + response.code(), null);
+                            return;
+                        }
+
+                        long written = writeRangeToFile(
+                                response.body().source(),
+                                file,
+                                start,
+                                totalDownloaded,
+                                totalLength
+                        );
+                        if (written < 0 || downloadCancelled || finished.get()) {
+                            return;
+                        }
+                        long expected = end - start + 1;
+                        if (written != expected) {
+                            failParallelDownload(finished, "Part " + partIndex + " downloaded " + written + " bytes, expected " + expected, null);
+                            return;
+                        }
+
+                        if (completedParts.incrementAndGet() == connectionCount && finished.compareAndSet(false, true)) {
+                            clearActiveCallReferences();
+                            if (file.length() != totalLength) {
+                                reportStatus(true, OtaStatus.DOWNLOAD_ERROR, "Downloaded file size does not match Content-Range total", null, null);
+                                return;
+                            }
+                            onDownloadComplete(destination, fileUri);
+                        }
                     } catch (StreamResetException ex) {
                         // Thrown when the call was canceled using 'cancel()'
-                        currentCall = null;
-                        return;
                     } catch (IOException | RuntimeException ex) {
-                        reportStatus(true, OtaStatus.DOWNLOAD_ERROR, ex.getMessage(), ex, null);
-                        currentCall = null;
-                        return;
+                        if (!downloadCancelled && !finished.get()) {
+                            failParallelDownload(finished, ex.getMessage(), ex);
+                        }
+                    } finally {
+                        response.close();
+                        removeActiveCall(call);
                     }
-                    onDownloadComplete(destination, fileUri);
-                    currentCall = null;
                 }
             });
-        } catch (Exception e) {
-            reportStatus(true, OtaStatus.INTERNAL_ERROR, e.getMessage(), e, null);
+        }
+    }
+
+    private Request.Builder buildRequest(String url) throws JSONException {
+        Request.Builder request = new Request.Builder()
+                .url(url);
+        if (headers != null) {
+            Iterator<String> jsonKeys = headers.keys();
+            while (jsonKeys.hasNext()) {
+                String headerName = jsonKeys.next();
+                String headerValue = headers.getString(headerName);
+                request.addHeader(headerName, headerValue);
+            }
+        }
+        return request;
+    }
+
+    private long parseTotalLengthFromContentRange(String contentRange) {
+        if (contentRange == null) {
+            return -1;
+        }
+        int separatorIndex = contentRange.lastIndexOf('/');
+        if (separatorIndex < 0 || separatorIndex == contentRange.length() - 1) {
+            return -1;
+        }
+        String totalLength = contentRange.substring(separatorIndex + 1).trim();
+        if (totalLength.equals("*")) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(totalLength);
+        } catch (NumberFormatException ex) {
+            Log.w(TAG, "Invalid Content-Range total length: " + contentRange, ex);
+            return -1;
+        }
+    }
+
+    private long writeRangeToFile(
+            BufferedSource source,
+            File file,
+            long start,
+            AtomicLong totalDownloaded,
+            long totalLength
+    ) throws IOException {
+        byte[] buffer = new byte[65536];
+        long partDownloaded = 0;
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
+            randomAccessFile.seek(start);
+            int bytesRead;
+            while ((bytesRead = source.read(buffer)) != -1) {
+                if (downloadCancelled) {
+                    return -1;
+                }
+                randomAccessFile.write(buffer, 0, bytesRead);
+                partDownloaded += bytesRead;
+                reportDownloadProgress(totalDownloaded.addAndGet(bytesRead), totalLength);
+            }
+        }
+        return partDownloaded;
+    }
+
+    private void reportDownloadProgress(long bytesDownloaded, long bytesTotal) {
+        if (bytesTotal < 1 || progressSink == null) {
+            return;
+        }
+        Message message = new Message();
+        Bundle data = new Bundle();
+        data.putLong(BYTES_DOWNLOADED, bytesDownloaded);
+        data.putLong(BYTES_TOTAL, bytesTotal);
+        message.setData(data);
+        handler.sendMessage(message);
+        contentLength = bytesTotal;
+    }
+
+    private void failParallelDownload(AtomicBoolean finished, String message, Exception e) {
+        if (finished.compareAndSet(false, true)) {
+            cancelActiveCalls();
+            clearActiveCallReferences();
+            reportStatus(true, OtaStatus.DOWNLOAD_ERROR, message, e, null);
+        }
+    }
+
+    private void addActiveCall(Call call) {
+        synchronized (callsLock) {
+            currentCalls.add(call);
+        }
+    }
+
+    private void removeActiveCall(Call call) {
+        synchronized (callsLock) {
+            currentCalls.remove(call);
+        }
+    }
+
+    private boolean hasActiveCalls() {
+        if (currentCall != null) {
+            return true;
+        }
+        synchronized (callsLock) {
+            return !currentCalls.isEmpty();
+        }
+    }
+
+    private void cancelActiveCalls() {
+        downloadCancelled = true;
+        if (currentCall != null) {
+            currentCall.cancel();
             currentCall = null;
         }
+        synchronized (callsLock) {
+            for (Call call : currentCalls) {
+                call.cancel();
+            }
+            currentCalls.clear();
+        }
+    }
+
+    private void clearActiveCallReferences() {
+        currentCall = null;
+        synchronized (callsLock) {
+            currentCalls.clear();
+        }
+        downloadRunning = false;
     }
 
     /**
@@ -570,6 +888,8 @@ public class OtaUpdatePlugin implements
                             .body(new ProgressResponseBody(originalResponse.body(), OtaUpdatePlugin.this))
                             .build();
                 })
+                .build();
+        rawClient = new OkHttpClient.Builder()
                 .build();
     }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,7 @@ class _MyAppState extends State<MyApp> {
             destinationFilename: 'flutter_hello_world.apk',
             //FOR NOW ANDROID ONLY - ABILITY TO VALIDATE CHECKSUM OF FILE:
             sha256checksum: '28cff8632531859634c4142ec704e86c5345244bddd6433b6160edaabc9b646a',
+            parallelDownloads: 4,
           )
           .listen((OtaEvent event) {
             setState(() => currentEvent = event);

--- a/lib/ota_update.dart
+++ b/lib/ota_update.dart
@@ -23,7 +23,12 @@ class OtaUpdate {
   }
 
   /// Execute download and instalation of the plugin.
-  /// Download progress and all success or error states are publish in stream as OtaEvent
+  /// Download progress and all success or error states are publish in stream as OtaEvent.
+  ///
+  /// On Android, [parallelDownloads] can be set above 1 to use multiple HTTP
+  /// range requests when the server supports them. The Android implementation
+  /// falls back to the default single request download when range requests are
+  /// unavailable. Values above 8 are capped by Android code.
   Stream<OtaEvent> execute(
     String url, {
     Map<String, String> headers = const <String, String>{},
@@ -31,9 +36,13 @@ class OtaUpdate {
     String? destinationFilename,
     String? sha256checksum,
     bool usePackageInstaller = false,
+    int parallelDownloads = 1,
   }) {
     if (destinationFilename != null && destinationFilename.contains('/')) {
       throw OtaUpdateException('Invalid filename $destinationFilename');
+    }
+    if (parallelDownloads < 1) {
+      throw OtaUpdateException('parallelDownloads must be greater than 0');
     }
     final StreamController<OtaEvent> controller = StreamController<OtaEvent>.broadcast();
     if (_progressStream == null) {
@@ -45,6 +54,7 @@ class OtaUpdate {
             'checksum': sha256checksum,
             'headers': jsonEncode(headers),
             'usePackageInstaller': usePackageInstaller ? 'true' : 'false',
+            'parallelDownloads': parallelDownloads.toString(),
           })
           .listen((dynamic event) {
             final OtaEvent otaEvent = _toOtaEvent(event.cast<String>());


### PR DESCRIPTION
## Summary
- add an opt-in `parallelDownloads` parameter for Android downloads
- use HTTP range requests to download APK chunks concurrently when the server supports ranges
- fall back to the existing single request download when range support cannot be confirmed
- keep checksum verification and installation flow unchanged

## Notes
- default behavior is unchanged because `parallelDownloads` defaults to `1`
- Android caps the requested connection count at `8`
- cancellation now cancels all active OkHttp calls for parallel downloads

## Verification
- `flutter analyze`
- `:ota_update:compileDebugJavaWithJavac`